### PR TITLE
fix types for export

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,14 @@ pipeline-prod: &pipeline-prod
       only:
         - main
 
+commands:
+  setup-npm:
+    description: "Setting up NPM"
+    steps:
+      - run:
+          working_directory: 'Builtin.Components'
+          command: |
+            echo "//npm.pkg.github.com/:_authToken=${GH_PAT_REPO}" >> .npmrc
 executors:
   base:
     docker:
@@ -50,6 +58,7 @@ jobs:
     executor: node
     steps:
       - checkout
+      - setup-npm
       - run:
           working_directory: 'blaze-slider'
           name: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
     description: "Setting up NPM"
     steps:
       - run:
-          working_directory: 'Builtin.Components'
+          working_directory: 'blaze-slider'
           command: |
             echo "//npm.pkg.github.com/:_authToken=${GH_PAT_REPO}" >> .npmrc
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,17 @@ orbs:
   aws-cli: circleci/aws-cli@3.1.4
 
 pipeline-feature: &pipeline-feature
+  context:
+    - write-github-packages
+    - aws-services
   filters:
     branches:
       ignore:
         - main
 pipeline-test: &pipeline-test
   context:
-    - aws-develop
-    - builtin-develop
+    - write-github-packages
+    - aws-services
   filters:
     branches:
       only:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@builtinx:registry=https://npm.pkg.github.com

--- a/blaze-slider/package.json
+++ b/blaze-slider/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
-  "name": "blaze-slider",
-  "version": "1.9.3",
+  "name": "@builtinx/blaze-slider",
+  "version": "1.0.1",
   "description": "Blazing Fast Slider For High Performance Web",
   "main": "dist/blaze-slider.cjs.js",
   "module": "dist/blaze-slider.esm.js",
@@ -27,6 +27,7 @@
         "import": "./dist/blaze-slider.esm.js",
         "require": "./dist/blaze-slider.cjs.dev.js"
       },
+      "types": "./dist/blaze-slider.esm.d.ts",
       "import": "./dist/blaze-slider.esm.js",
       "require": "./dist/blaze-slider.cjs.prod.js"
     },

--- a/blaze-slider/package.json
+++ b/blaze-slider/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
-  "name": "@builtinx/blaze-slider",
-  "version": "1.0.1",
+  "name": "blaze-slider",
+  "version": "1.9.3",
   "description": "Blazing Fast Slider For High Performance Web",
   "main": "dist/blaze-slider.cjs.js",
   "module": "dist/blaze-slider.esm.js",

--- a/blaze-slider/package.json
+++ b/blaze-slider/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
-  "name": "blaze-slider",
-  "version": "1.9.3",
+  "name": "@builtinx/blaze-slider",
+  "version": "1.0.1",
   "description": "Blazing Fast Slider For High Performance Web",
   "main": "dist/blaze-slider.cjs.js",
   "module": "dist/blaze-slider.esm.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       }
     },
     "blaze-slider": {
-      "version": "1.9.3",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",
@@ -17362,6 +17362,11 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "website/node_modules/blaze-slider": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/blaze-slider/-/blaze-slider-1.9.3.tgz",
+      "integrity": "sha512-u8i4AhbjICF6gpyKeMEg65kupT2JoN+E7yOJjOt3ocUtS+r4SKYU79DPNSBV2Zb61fix4ChIxfPyyRUSmLao5g=="
+    },
     "website/node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -29136,6 +29141,11 @@
             "webpack": "^5.73.0",
             "webpack-merge": "^5.8.0"
           }
+        },
+        "blaze-slider": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/blaze-slider/-/blaze-slider-1.9.3.tgz",
+          "integrity": "sha512-u8i4AhbjICF6gpyKeMEg65kupT2JoN+E7yOJjOt3ocUtS+r4SKYU79DPNSBV2Zb61fix4ChIxfPyyRUSmLao5g=="
         },
         "commander": {
           "version": "5.1.0",


### PR DESCRIPTION
Types used to be prioritized over export so types was missing this should add types to the export
https://github.com/microsoft/TypeScript/wiki/Breaking-Changes?utm_source=chatgpt.com#exports-is-prioritized-over-typesversions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated package name and version for the `blaze-slider` package to enhance clarity and versioning.
	- Modified pipeline configurations to improve context settings for feature and test pipelines.
	- Added a custom registry configuration for `@builtinx` in the npm settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->